### PR TITLE
Refactor of unix domain related classes by using NIO base classes (Java 7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/jnr/enxio/channels/AbstractNativeSocketChannel.java
+++ b/src/main/java/jnr/enxio/channels/AbstractNativeSocketChannel.java
@@ -139,6 +139,7 @@ public abstract class AbstractNativeSocketChannel extends SocketChannel
 		return result;
 	}
 
+	@Override
 	public SocketChannel shutdownInput() throws IOException {
 		int n = Native.shutdown(fd, SHUT_RD);
 		if (n < 0) {
@@ -147,6 +148,7 @@ public abstract class AbstractNativeSocketChannel extends SocketChannel
 		return this;
 	}
 
+	@Override
 	public SocketChannel shutdownOutput() throws IOException {
 		int n = Native.shutdown(fd, SHUT_WR);
 		if (n < 0) {

--- a/src/main/java/jnr/unixsocket/UnixSocketChannel.java
+++ b/src/main/java/jnr/unixsocket/UnixSocketChannel.java
@@ -23,7 +23,9 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SocketChannel;
 import java.nio.channels.UnsupportedAddressTypeException;
+import java.util.Set;
 
 import jnr.constants.platform.Errno;
 import jnr.constants.platform.ProtocolFamily;
@@ -301,7 +303,6 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
 		}
 	}
 	
-	/**
 
 	@Override
 	public SocketAddress getRemoteAddress() throws IOException {
@@ -310,8 +311,7 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
 
 	@Override
 	public SocketAddress getLocalAddress() throws IOException {
-		throw new UnsupportedOperationException(
-				"getLocalAddress is not supported");
+		return localAddress;
 	}
 
 	@Override
@@ -335,6 +335,4 @@ public class UnixSocketChannel extends AbstractNativeSocketChannel {
 			throws IOException {
 		throw new UnsupportedOperationException("setOption is not supported");
 	}
-	
-	**/
 }


### PR DESCRIPTION
This is a work-in-progress PR that refactors `UnixSocketChannel` to extend `java.nio.channels.SocketChannel` as well as implement a `UnixDatagramChannel` that extends `java.nio.channels.DatagramChannel` by @felfert. The goal is to extract common base classes for both channel implementations.
